### PR TITLE
refactor: add reproduce area options in debug-map menu

### DIFF
--- a/src/debug_menu.cpp
+++ b/src/debug_menu.cpp
@@ -1526,7 +1526,7 @@ void debug()
             } );
 
             for( Creature *critter : creatures ) {
-                static_cast<monster *>( critter )->try_reproduce( true );
+                static_cast<monster *>( critter )->reproduce();
             }
         }
         break;

--- a/src/monster.h
+++ b/src/monster.h
@@ -122,8 +122,10 @@ class monster : public Creature, public location_visitable<monster>
         int get_upgrade_time() const;
         void allow_upgrade();
         void try_upgrade( bool pin_time );
-        // check if monster should reproduce. boolean parameter can force reproduction
-        void try_reproduce( const bool force_reproduce = false );
+        /// Check if monster is ready to reproduce and do so if possible, refreshing baby timer.
+        void try_reproduce();
+        /// Immediatly spawn an offspring without mutating baby timer.
+        void reproduce();
         void refill_udders();
         void spawn( const tripoint &p );
         m_size get_size() const override;


### PR DESCRIPTION
simplify `try_reproduce()` by removing the check for whether it's forceful in logic and adding `reproduce()` instead.